### PR TITLE
Use root locale when converting strings

### DIFF
--- a/common/src/main/java/mod/azure/azurelib/common/internal/client/config/widget/ColorWidget.java
+++ b/common/src/main/java/mod/azure/azurelib/common/internal/client/config/widget/ColorWidget.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.IntSupplier;
@@ -102,7 +103,7 @@ public final class ColorWidget extends AbstractWidget {
         );
         dialog.onConfirmed(screen -> {
             int color = dialog.getResultColor();
-            String colorText = this.colorPrefix + Integer.toHexString(color).toUpperCase();
+            String colorText = this.colorPrefix + Integer.toHexString(color).toUpperCase(Locale.ROOT);
             this.colorWidget.set(colorText);
             dialog.displayPreviousScreen(dialog);
         });
@@ -257,7 +258,7 @@ public final class ColorWidget extends AbstractWidget {
             ColorComponent(int bitOffset) {
                 this.bitOffset = bitOffset;
                 this.title = val -> {
-                    String name = this.name().toLowerCase();
+                    String name = this.name().toLowerCase(Locale.ROOT);
                     String translate = "text.azurelib.screen.color." + name;
                     int colorValue = (int) (val * 255);
                     return Component.translatable(translate, colorValue);

--- a/common/src/main/java/mod/azure/azurelib/core/molang/MolangParser.java
+++ b/common/src/main/java/mod/azure/azurelib/core/molang/MolangParser.java
@@ -21,6 +21,7 @@ import mod.azure.azurelib.core.molang.functions.CosDegrees;
 import mod.azure.azurelib.core.molang.functions.SinDegrees;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.DoubleSupplier;
 
@@ -78,7 +79,7 @@ public class MolangParser extends MathBuilder {
     public static MolangValue parseExpression(String expression) throws MolangException {
         MolangCompoundValue result = null;
 
-        for (String split : expression.toLowerCase().trim().split(";")) {
+        for (String split : expression.toLowerCase(Locale.ROOT).trim().split(";")) {
             String trimmed = split.trim();
 
             if (!trimmed.isEmpty()) {


### PR DESCRIPTION
Fixes #70

Changes to ColorWidget aren't strictly necessary since none of the strings converted to upper- or lowercase should ever contain an 'i', but just to be safe since they should be converted using the root locale regardless.