### PR TITLE
Add an optional Waist Bone for armors

### DIFF
--- a/common/src/main/java/mod/azure/azurelib/rewrite/render/armor/bone/AzArmorBoneContext.java
+++ b/common/src/main/java/mod/azure/azurelib/rewrite/render/armor/bone/AzArmorBoneContext.java
@@ -29,6 +29,8 @@ public class AzArmorBoneContext {
 
     public AzBone leftBoot;
 
+    public AzBone waist;
+
     public AzArmorBoneContext() {
         this.head = null;
         this.body = null;
@@ -38,6 +40,7 @@ public class AzArmorBoneContext {
         this.leftLeg = null;
         this.rightBoot = null;
         this.leftBoot = null;
+        this.waist = null;
     }
 
     public void setAllVisible(boolean pVisible) {
@@ -49,6 +52,7 @@ public class AzArmorBoneContext {
         setBoneVisible(this.leftLeg, pVisible);
         setBoneVisible(this.rightBoot, pVisible);
         setBoneVisible(this.leftBoot, pVisible);
+        setBoneVisible(this.waist, pVisible);
     }
 
     /**
@@ -68,6 +72,7 @@ public class AzArmorBoneContext {
         this.leftLeg = boneProvider.getLeftLegBone(model);
         this.rightBoot = boneProvider.getRightBootBone(model);
         this.leftBoot = boneProvider.getLeftBootBone(model);
+        this.waist = boneProvider.getWaistBone(model);
     }
 
     /**
@@ -101,6 +106,7 @@ public class AzArmorBoneContext {
             RenderUtils.matchModelPartRot(leftArmPart, this.leftArm);
             this.leftArm.updatePosition(leftArmPart.x - 5f, 2f - leftArmPart.y, leftArmPart.z);
         }
+        boolean waistRendered = false;
 
         if (this.rightLeg != null) {
             ModelPart rightLegPart = baseModel.rightLeg;
@@ -111,6 +117,12 @@ public class AzArmorBoneContext {
             if (this.rightBoot != null) {
                 RenderUtils.matchModelPartRot(rightLegPart, this.rightBoot);
                 this.rightBoot.updatePosition(rightLegPart.x + 2, 12 - rightLegPart.y, rightLegPart.z);
+            }
+            if (this.waist != null) {
+
+                RenderUtils.matchModelPartRot(baseModel.body, this.waist);
+                this.waist.updatePosition(baseModel.body.x, -(baseModel.body.y), baseModel.body.z);
+                waistRendered = true;
             }
         }
 
@@ -123,6 +135,12 @@ public class AzArmorBoneContext {
             if (this.leftBoot != null) {
                 RenderUtils.matchModelPartRot(leftLegPart, this.leftBoot);
                 this.leftBoot.updatePosition(leftLegPart.x - 2, 12 - leftLegPart.y, leftLegPart.z);
+            }
+            if (!waistRendered && this.waist != null) {
+
+                RenderUtils.matchModelPartRot(baseModel.body, this.waist);
+                this.waist.updatePosition(baseModel.body.x, -(baseModel.body.y), baseModel.body.z);
+                waistRendered = true;
             }
         }
     }
@@ -138,6 +156,7 @@ public class AzArmorBoneContext {
 
         currentPart.visible = true;
         AzBone bone = null;
+        AzBone waistBone = null;
 
         if (currentPart == model.hat || currentPart == model.head) {
             bone = this.head;
@@ -149,12 +168,18 @@ public class AzArmorBoneContext {
             bone = this.rightArm;
         } else if (currentPart == model.leftLeg) {
             bone = currentSlot == EquipmentSlot.FEET ? this.leftBoot : this.leftLeg;
+            waistBone = currentSlot == EquipmentSlot.LEGS ? this.waist : null;
         } else if (currentPart == model.rightLeg) {
             bone = currentSlot == EquipmentSlot.FEET ? this.rightBoot : this.rightLeg;
+            waistBone = currentSlot == EquipmentSlot.LEGS ? this.waist : null;
+
         }
 
         if (bone != null) {
             bone.setHidden(false);
+        }
+        if (waistBone != null) {
+            waistBone.setHidden(false);
         }
     }
 
@@ -173,10 +198,14 @@ public class AzArmorBoneContext {
                 setBoneVisible(this.body, true);
                 setBoneVisible(this.rightArm, true);
                 setBoneVisible(this.leftArm, true);
+                setBoneVisible(this.waist, false);
+
             }
             case LEGS -> {
                 setBoneVisible(this.rightLeg, true);
                 setBoneVisible(this.leftLeg, true);
+                setBoneVisible(this.waist, true);
+
             }
             case FEET -> {
                 setBoneVisible(this.rightBoot, true);

--- a/common/src/main/java/mod/azure/azurelib/rewrite/render/armor/bone/AzArmorBoneProvider.java
+++ b/common/src/main/java/mod/azure/azurelib/rewrite/render/armor/bone/AzArmorBoneProvider.java
@@ -23,6 +23,8 @@ public interface AzArmorBoneProvider {
 
     String BONE_ARMOR_RIGHT_LEG_NAME = "armorRightLeg";
 
+    String BONE_ARMOR_WAIST_NAME = "armorWaist";
+
     /**
      * Returns the 'head' GeoBone from this model.<br>
      * Override if your geo model has different bone names for these bones
@@ -94,4 +96,13 @@ public interface AzArmorBoneProvider {
      */
     @Nullable
     AzBone getLeftBootBone(AzBakedModel model);
+
+    /**
+     * Returns the 'waist' GeoBone from this model.<br>
+     * Override if your geo model has different bone names for these bones
+     *
+     * @return The bone for the waist model piece, or null if not using it
+     */
+    @Nullable
+    AzBone getWaistBone(AzBakedModel model);
 }

--- a/common/src/main/java/mod/azure/azurelib/rewrite/render/armor/bone/AzDefaultArmorBoneProvider.java
+++ b/common/src/main/java/mod/azure/azurelib/rewrite/render/armor/bone/AzDefaultArmorBoneProvider.java
@@ -46,4 +46,9 @@ public class AzDefaultArmorBoneProvider implements AzArmorBoneProvider {
     public AzBone getLeftBootBone(AzBakedModel model) {
         return model.getBoneOrNull(BONE_ARMOR_LEFT_BOOT_NAME);
     }
+
+    @Nullable
+    public AzBone getWaistBone(AzBakedModel model) {
+        return model.getBoneOrNull(BONE_ARMOR_WAIST_NAME);
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -51,5 +51,5 @@ mod_logo                             = azurelib.png
 mod_name                             = AzureLib
 mod_sources                          = https://github.com/AzureDoom/AzureLib
 mod_url                              = https://modrinth.com/mod/azurelib
-version                              = 3.0.38
+version                              = 3.0.39
 modrinth_id                          = 7zlUOZvb


### PR DESCRIPTION
In vanilla minecraft, leggings usually have a waist bone that is present when put on
This PR allows you to define an "armorWaist" bone that renders when at least one leg of the armor is present. 