### PR TITLE
NullPointerException originating from the render method

### DIFF
--- a/common/src/main/java/mod/azure/azurelib/common/render/entity/AzEntityRenderer.java
+++ b/common/src/main/java/mod/azure/azurelib/common/render/entity/AzEntityRenderer.java
@@ -72,6 +72,11 @@ public abstract class AzEntityRenderer<T extends Entity> extends EntityRenderer<
         @NotNull MultiBufferSource bufferSource,
         int packedLight
     ) {
+        // If the entity is invisible, then we don't need to render it
+        if (entity.isInvisible()) {
+            return;
+        }
+
         var cachedEntityAnimator = (AzEntityAnimator<T>) provider.provideAnimator(entity, entity);
         var azBakedModel = provider.provideBakedModel(entity, entity);
 


### PR DESCRIPTION
This resolves the issue with:
https://github.com/AzureDoom/AzureLib/issues/175

This resolves a client side crash where it was trying to render an entity while being invisible. It was reported to me as a user was using Mob Control to set the entity invisible, which then incited this bug to occur. Here's the actual line in the log:

`Caused by: java.lang.NullPointerException: Cannot invoke "net.minecraft.client.renderer.RenderType.mode()" because "p_109919_" is null`

Full logs available at request.